### PR TITLE
Add epsg hsql dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,10 @@
         </repository>
         <repository>
             <id>os-geo</id>
-            <name>os-geo</name>
-            <url>https://download.osgeo.org/webdav/geotools</url>
+            <name>OSGeo Release Repository</name>
+            <url>https://repo.osgeo.org/repository/release/</url>
+            <snapshots><enabled>false</enabled></snapshots>
+            <releases><enabled>true</enabled></releases>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
             <version>10.5</version>
         </dependency>
         <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+            <version>10.5</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.1</version>


### PR DESCRIPTION
While fixing elevation service [build issue](https://github.com/komoot/elevation/pull/4) I found out that it happens because it is missing gt-epsg-hsql. I think it is better to add this dependency here since it is needed because of this.

I also updated osgeo repository url based on emils [post](https://komootteam.slack.com/archives/C69RFAJNB/p1587726622230300?thread_ts=1587720227.221000&cid=C69RFAJNB), because packages weren't found anymore at the old one.